### PR TITLE
Fix coordinate order in report submissions

### DIFF
--- a/components/map/hooks/useReportActions.ts
+++ b/components/map/hooks/useReportActions.ts
@@ -23,7 +23,7 @@ export default function useReportActions({ addReport, mutateReport, userId, open
       return;
     }
     // Default location if loc is null
-    const [lon, lat] = loc ?? [-97.7431, 30.2672]; 
+    const [lat, lon] = loc ?? [30.2672, -97.7431];
     const fd = new FormData();
     fd.append("latitude", lat.toString());
     fd.append("longitude", lon.toString());
@@ -55,7 +55,7 @@ export default function useReportActions({ addReport, mutateReport, userId, open
       setSuccess(true);
       const newReport: PollutionReport = {
         id: json.reportId,
-        location: [lon, lat],
+        location: [lat, lon],
         type: "user",
         severity: data.severity,
         description: data.description,

--- a/components/map/types.ts
+++ b/components/map/types.ts
@@ -2,7 +2,7 @@
 
 export interface TrashBin {
   id: string;
-  location: [number, number]; // [longitude, latitude]
+  location: [number, number]; // [latitude, longitude]
   name?: string;
   capacity?: string;
   lastEmptied?: string;
@@ -46,7 +46,7 @@ export interface SupabaseReport {
 // Represents the processed pollution report used in the frontend map state
 export interface PollutionReport {
   id: string;
-  location: [number, number]; // [longitude, latitude]
+  location: [number, number]; // [latitude, longitude]
   type: "user" | "311" | "historical"; // Added historical based on old map.tsx
   severity: number; // 1-5
   description?: string;

--- a/components/report-modal.tsx
+++ b/components/report-modal.tsx
@@ -116,7 +116,7 @@ export default function ReportModal({ isOpen, onClose, onSubmit, userLocation, i
       }
       
       const submitData: ReportSubmitData = {
-        location: userLocation || [-97.7431, 30.2672],
+        location: userLocation || [30.2672, -97.7431],
         description,
         severity: severity[0],
         imageFile: imageFile,
@@ -271,7 +271,7 @@ export default function ReportModal({ isOpen, onClose, onSubmit, userLocation, i
 
           {userLocation ? (
             <div className="text-sm text-muted-foreground">
-              Location: {userLocation[1].toFixed(6)}, {userLocation[0].toFixed(6)}
+              Location: {userLocation[0].toFixed(6)}, {userLocation[1].toFixed(6)}
             </div>
           ) : (
             <div className="text-sm text-amber-500">


### PR DESCRIPTION
## Summary
- correct default location and coordinate order when submitting reports
- clarify coordinate orientation comments
- display latitude before longitude in report modal

## Testing
- `npm run lint` *(fails: `next` not found)*