### PR TITLE
Add image compression

### DIFF
--- a/app/api/reports/classify/route.ts
+++ b/app/api/reports/classify/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabaseServer';
-import sharp from 'sharp';
 import { Buffer } from 'buffer';
+import { optimizeImage } from '@/lib/imageServer'
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient();
@@ -29,14 +29,8 @@ export async function POST(request: NextRequest) {
 
     const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
 
-    // Optimize image using Sharp
-    const optimizedImageBuffer = await sharp(imageBuffer)
-      .resize(768, 768, {
-        fit: 'inside',
-        withoutEnlargement: true
-      })
-      .webp({ quality: 80 })
-      .toBuffer();
+    // Optimize image and ensure it's under 3MB
+    const optimizedImageBuffer = await optimizeImage(imageBuffer);
 
     // --- START: HuggingFace Image Classification ---
     let classificationData = null;

--- a/app/api/reports/clean/route.ts
+++ b/app/api/reports/clean/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabaseServer';
-import sharp from 'sharp';
 import { Buffer } from 'buffer';
+import { optimizeImage } from '@/lib/imageServer'
 
 // Define points awarded for cleaning
 const POINTS_FOR_CLEANING = 25;
@@ -39,15 +39,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Optimize image
+    // Optimize image and ensure it's under 3MB
     const imageBuffer = Buffer.from(await image.arrayBuffer());
-    const optimizedImageBuffer = await sharp(imageBuffer)
-      .resize(768, 768, {
-        fit: 'inside',
-        withoutEnlargement: true
-      })
-      .webp({ quality: 80 })
-      .toBuffer();
+    const optimizedImageBuffer = await optimizeImage(imageBuffer);
 
     // 1. Upload optimized "cleaned" image
     // Use a slightly different naming convention or path

--- a/app/api/reports/create/route.ts
+++ b/app/api/reports/create/route.ts
@@ -2,9 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import OpenAI from "openai";
 import { z } from "zod";
 import { createClient } from '@/lib/supabaseServer'
-import sharp from 'sharp';
 import { Buffer } from 'buffer';
 import exifParser from 'exif-parser';
+import { optimizeImage } from '@/lib/imageServer'
 
 const openai = new OpenAI(); // Assumes OPENAI_API_KEY is set in environment
 
@@ -125,14 +125,8 @@ export async function POST(request: NextRequest) {
         console.log("Using Default coordinates for report.");
     }
 
-    // Optimize image using Sharp first
-    const optimizedImageBuffer = await sharp(imageBuffer)
-      .resize(768, 768, {
-        fit: 'inside',
-        withoutEnlargement: true
-      })
-      .webp({ quality: 80 })
-      .toBuffer();
+    // Optimize image and ensure it's under 3MB
+    const optimizedImageBuffer = await optimizeImage(imageBuffer);
       
     // --- START: OpenAI Validation --- 
     let environmentValidationResult: EnvironmentValidationResult;

--- a/lib/imageClient.ts
+++ b/lib/imageClient.ts
@@ -1,0 +1,24 @@
+export const MAX_IMAGE_BYTES = 3 * 1024 * 1024 // 3MB
+
+export async function compressImageFile(file: File, maxBytes: number = MAX_IMAGE_BYTES): Promise<File> {
+  const bitmap = await createImageBitmap(file)
+  const canvas = document.createElement('canvas')
+  const scale = Math.min(1, 768 / Math.max(bitmap.width, bitmap.height))
+  canvas.width = Math.round(bitmap.width * scale)
+  canvas.height = Math.round(bitmap.height * scale)
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Canvas not supported')
+  ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height)
+
+  let quality = 0.8
+  let blob = await new Promise<Blob | null>(resolve => canvas.toBlob(resolve, 'image/webp', quality))
+  if (!blob) throw new Error('Compression failed')
+
+  while (blob.size > maxBytes && quality > 0.4) {
+    quality -= 0.1
+    blob = await new Promise<Blob | null>(resolve => canvas.toBlob(resolve, 'image/webp', quality))
+    if (!blob) throw new Error('Compression failed')
+  }
+
+  return new File([blob], file.name.replace(/\.[^.]+$/, '.webp'), { type: 'image/webp' })
+}

--- a/lib/imageServer.ts
+++ b/lib/imageServer.ts
@@ -1,0 +1,21 @@
+import sharp from 'sharp'
+
+export const MAX_IMAGE_BYTES = 3 * 1024 * 1024 // 3MB
+
+export async function optimizeImage(buffer: Buffer, maxBytes: number = MAX_IMAGE_BYTES): Promise<Buffer> {
+  let quality = 80
+  let output = await sharp(buffer)
+    .resize(768, 768, { fit: 'inside', withoutEnlargement: true })
+    .webp({ quality })
+    .toBuffer()
+
+  while (output.byteLength > maxBytes && quality > 40) {
+    quality -= 10
+    output = await sharp(buffer)
+      .resize(768, 768, { fit: 'inside', withoutEnlargement: true })
+      .webp({ quality })
+      .toBuffer()
+  }
+
+  return output
+}


### PR DESCRIPTION
## Summary
- add utilities for compressing images client and server side
- use these utilities in report creation, cleaning, and classification API routes
- compress uploaded image files before submission in `ReportModal`

## Testing
- `npm run lint` *(fails: `next` not found)*